### PR TITLE
feat: API 호출 별 로컬 캐싱 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/react-dom": "^18.2.1",
         "@types/styled-components": "^5.1.26",
         "axios": "^1.4.0",
+        "http-proxy-middleware": "^2.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@types/react-dom": "^18.2.1",
     "@types/styled-components": "^5.1.26",
     "axios": "^1.4.0",
+    "http-proxy-middleware": "^2.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/api/ApiUrl.ts
+++ b/src/api/ApiUrl.ts
@@ -1,5 +1,5 @@
 class ApiUrl {
-  static relatedKeywords = 'v1/search-conditions/?name=';
+  static relatedKeywords = '/api/v1/search-conditions/?name=';
 }
 
 export default ApiUrl;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,9 +1,12 @@
-import axios from 'axios';
+export {};
 
-const BASE_URL = 'https://api.clinicaltrialskorea.com/api/';
+// TODO: CORS 에러를 해결하기 위해 instance 사용을 잠시 중단함
+// import axios from 'axios';
 
-const instance = axios.create({
-  baseURL: BASE_URL,
-});
+// const BASE_URL = 'https://api.clinicaltrialskorea.com/api/';
 
-export default instance;
+// const instance = axios.create({
+//   baseURL: BASE_URL,
+// });
+
+// export default instance;

--- a/src/api/relatedKeywords.ts
+++ b/src/api/relatedKeywords.ts
@@ -1,10 +1,19 @@
-import instance from '.';
+import axios from 'axios';
 
 import ApiUrl from './ApiUrl';
 
+// TODO: CORS 에러 해결을 위해 instance 사용을 중단함. 추후 결정하기
+// const fetchRelatedKeywords = async (keyword: string) => {
+//   const { data } = await instance.get(`${ApiUrl.relatedKeywords}${keyword}`, {
+//     headers: { 'Cache-Control': 'no-cache' },
+//   });
+//   console.info('calling api');
+//   return data;
+// };
+
 const fetchRelatedKeywords = async (keyword: string) => {
-  const { data } = await instance.get(`${ApiUrl.relatedKeywords}${keyword}`);
-  console.info('calling api');
+  const { data } = await axios.get(`${ApiUrl.relatedKeywords}${keyword}`);
+
   return data;
 };
 

--- a/src/api/relatedKeywords.ts
+++ b/src/api/relatedKeywords.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 import ApiUrl from './ApiUrl';
 
 // TODO: CORS 에러 해결을 위해 instance 사용을 중단함. 추후 결정하기
@@ -11,10 +9,44 @@ import ApiUrl from './ApiUrl';
 //   return data;
 // };
 
-const fetchRelatedKeywords = async (keyword: string) => {
-  const { data } = await axios.get(`${ApiUrl.relatedKeywords}${keyword}`);
+const getCachedData = async (cacheName: string, url: string) => {
+  const cacheStorage = await caches.open(cacheName);
+  const cachedResponse = await cacheStorage.match(url);
 
-  return data;
+  if (!cachedResponse || !cachedResponse.ok) {
+    return false;
+  }
+
+  const result = await cachedResponse.json();
+
+  return result;
+};
+
+const getData = async (keyword: string) => {
+  const cacheName = 'relatedKeywords';
+  const URL = `${ApiUrl.relatedKeywords}${keyword}`;
+
+  const cachedData = await getCachedData(cacheName, URL);
+
+  if (cachedData) {
+    return cachedData;
+  }
+
+  const cacheStorage = await caches.open(cacheName);
+  await cacheStorage.add(URL);
+
+  const result = await getCachedData(cacheName, URL);
+
+  return result;
+};
+
+const fetchRelatedKeywords = async (keyword: string) => {
+  try {
+    const data = await getData(keyword);
+    return data;
+  } catch (error) {
+    return error;
+  }
 };
 
 export default fetchRelatedKeywords;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
 root.render(
   <React.StrictMode>
     <App />

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: 'https://api.clinicaltrialskorea.com',
+      changeOrigin: true,
+    }),
+  );
+};


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature

## 🤹‍♀️ What is the current behavior?

- [x] 캐싱 기능 포함된 라이브러리 사용 제외
- [x] 캐싱 구현
- [x] 구현 기술에 대한 요약

Issue Number: #5 closed

## 📸 Screenshots
### '갑상선' 단어 검색 시 Cache Storage에 결과물 저장
<img width="1337" alt="스크린샷 2023-05-03 오후 11 29 40" src="https://user-images.githubusercontent.com/104840243/235946850-2366db3a-cdfc-4310-943f-731b378d8a64.png">

### 캐시된 '갑상선' 단어에 대한 결과를 Cache Storage에서 받아오므로 Network 탭에서 request 확인되지 않음
<img width="1349" alt="스크린샷 2023-05-03 오후 11 30 46" src="https://user-images.githubusercontent.com/104840243/235947222-a7540e76-016c-41cf-a965-e81300d667ea.png">

## 💬 Other information
- 가산점이 부여되는 expire time은 구현하지 않았음