### PR TITLE
feat: 키보드로 추천 검색어 이동 기능 구현

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -2,3 +2,8 @@ export type RelatedKeyword = {
   name: string;
   id: number;
 };
+
+export type FocusedState = {
+  isFirstMoving: boolean;
+  focusedIndex: number;
+};

--- a/src/components/KeywordLine.tsx
+++ b/src/components/KeywordLine.tsx
@@ -1,9 +1,16 @@
+import styled from 'styled-components';
+
+const List = styled.li`
+  background: ${(props) => props.className === 'true' && 'gray'};
+`;
+
 type KeywordLineProps = {
   name: string;
+  isFocused: boolean;
 };
 
-const KeywordLine = ({ name }: KeywordLineProps) => {
-  return <li>{name}</li>;
+const KeywordLine = ({ name, isFocused }: KeywordLineProps) => {
+  return <List className={String(isFocused)}>{name}</List>;
 };
 
 export default KeywordLine;

--- a/src/components/RelatedKeywordsList.tsx
+++ b/src/components/RelatedKeywordsList.tsx
@@ -1,20 +1,27 @@
 import KeywordLine from './KeywordLine';
 
-import { RelatedKeyword } from '../@types/types';
+import { FocusedState, RelatedKeyword } from '../@types/types';
 
 type RelatedKeywordsListProps = {
   relatedKeywords: RelatedKeyword[];
+  focusedState: FocusedState;
 };
 
-const RelatedKeywordsList = ({ relatedKeywords }: RelatedKeywordsListProps) => {
+const RelatedKeywordsList = ({ relatedKeywords, focusedState }: RelatedKeywordsListProps) => {
   return (
     <div>
       <p>추천 검색어</p>
       <ul>
         {relatedKeywords.length ? (
-          relatedKeywords.map((keyword) => <KeywordLine key={keyword.id} name={keyword.name} />)
+          relatedKeywords.map((keyword, index) => (
+            <KeywordLine
+              key={keyword.id}
+              name={keyword.name}
+              isFocused={focusedState.focusedIndex === index}
+            />
+          ))
         ) : (
-          <KeywordLine key="0" name="검색어 없음" />
+          <KeywordLine key="-" name="검색어 없음" isFocused={false} />
         )}
       </ul>
     </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,10 +1,10 @@
 type SearchBarProps = {
   inputText: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyPress: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 };
 
-const SearchBar = ({ inputText, onChange, handleKeyDown }: SearchBarProps) => {
+const SearchBar = ({ inputText, onChange, onKeyPress: onKeyDown }: SearchBarProps) => {
   return (
     <div>
       <label htmlFor="search-input">
@@ -14,7 +14,7 @@ const SearchBar = ({ inputText, onChange, handleKeyDown }: SearchBarProps) => {
           name="search-input"
           value={inputText}
           onChange={onChange}
-          onKeyDown={handleKeyDown}
+          onKeyDown={onKeyDown}
         />
       </label>
       <button type="button">검색</button>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -7,8 +7,15 @@ import RelatedKeywordsList from '../components/RelatedKeywordsList';
 import useDebounce from '../hooks/useDebounce';
 import useFetchRelatedKeywords from '../hooks/useFetchRelatedKeywords';
 
+import keyDownEventProcessor from '../utils/keyDownEventProcessor';
+
+import { FocusedState } from '../@types/types';
+
+const initialFocusedState = { isFirstMoving: true, focusedIndex: -1 };
+
 const SearchPage = () => {
-  const [inputText, setInputText] = useState('');
+  const [inputText, setInputText] = useState<string>('');
+  const [focusedState, setFocusedState] = useState<FocusedState>(initialFocusedState);
 
   const debouncedValue = useDebounce(inputText, 300);
   const { isError, relatedKeywords } = useFetchRelatedKeywords(debouncedValue);
@@ -19,19 +26,30 @@ const SearchPage = () => {
     setInputText(value);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = event;
 
-    if (key === 'Enter') {
-      // TODO: 이벤트핸들링 추가
+    if (!relatedKeywords.length) {
+      return;
     }
+
+    if (key === 'ArrowDown' || key === 'ArrowUp') {
+      const processedFocusedState = keyDownEventProcessor(key, focusedState, relatedKeywords);
+
+      setFocusedState(processedFocusedState);
+      return;
+    }
+
+    setFocusedState(initialFocusedState);
   };
 
   return (
     <div>
       <Title />
-      <SearchBar inputText={inputText} onChange={handleChange} handleKeyDown={handleKeyDown} />
-      {isError ? null : <RelatedKeywordsList relatedKeywords={relatedKeywords} />}
+      <SearchBar inputText={inputText} onChange={handleChange} onKeyPress={handleKeyPress} />
+      {isError ? null : (
+        <RelatedKeywordsList relatedKeywords={relatedKeywords} focusedState={focusedState} />
+      )}
     </div>
   );
 };

--- a/src/utils/keyDownEventProcessor.ts
+++ b/src/utils/keyDownEventProcessor.ts
@@ -1,0 +1,34 @@
+import { FocusedState, RelatedKeyword } from '../@types/types';
+
+const keyDownEventProcessor = (key: string, focusedState: FocusedState, data: RelatedKeyword[]) => {
+  const minIndex = 0;
+  const maxIndex = data.length - 1;
+
+  if (key === 'ArrowDown') {
+    if (focusedState.isFirstMoving) {
+      return { isFirstMoving: false, focusedIndex: 0 };
+    }
+
+    const currentIndex = focusedState.focusedIndex + 1;
+
+    return currentIndex > maxIndex
+      ? { ...focusedState, focusedIndex: 0 }
+      : { ...focusedState, focusedIndex: currentIndex };
+  }
+
+  if (key === 'ArrowUp') {
+    if (focusedState.isFirstMoving) {
+      return { isFirstMoving: false, focusedIndex: maxIndex };
+    }
+
+    const currentIndex = focusedState.focusedIndex - 1;
+
+    return currentIndex < minIndex
+      ? { ...focusedState, focusedIndex: maxIndex }
+      : { ...focusedState, focusedIndex: currentIndex };
+  }
+
+  return focusedState;
+};
+
+export default keyDownEventProcessor;


### PR DESCRIPTION
## 🚀 PR Type

- [x] Feature

## 🤹‍♀️ What is the current behavior?

- [x] input에 커서가 있을 때, 아래 방향 키를 누르면 추천 검색어로 이동
- [x] 선택된 검색어가 highlight 됨

Issue Number: #7 closed

## 📸 Screenshots
<img width="714" alt="스크린샷 2023-05-04 오전 8 49 58" src="https://user-images.githubusercontent.com/104840243/236075045-eb0954ff-8344-4c93-a72a-97a5c3130196.png">

## 💬 Other information
- 디자인은 추후 적용 예정
- 한글 입력에 따라 함수가 두 번 호출되는 상황 수정 예정